### PR TITLE
Increase parsing limit to 500 for anime_genre

### DIFF
--- a/anime/anime_genre.yml
+++ b/anime/anime_genre.yml
@@ -30,7 +30,7 @@ templates:
   anime_genre:
     mal_genre:
       genre_id: <<genre_id>>
-      limit: 300
+      limit: 500
     url_poster: https://raw.githubusercontent.com/Drazzilb08/pmm-custom-repo-posters/master/anime_genre/<<collection_name_encoded>>.jpg
 
 collections:


### PR DESCRIPTION
increases parasing limit for anime_genres for MAL - increases run time for PMM but grabs more anime to genre collections